### PR TITLE
BREAKING: remove the default flag value for --v

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -22,7 +22,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/component-base/logs"
 
@@ -51,23 +50,7 @@ func NewCertManagerCtlCommand(ctx context.Context, in io.Reader, out, err io.Wri
 	}
 	cmds.SetUsageTemplate(usageTemplate())
 
-	{
-		var logFlags pflag.FlagSet
-		logf.AddFlagsNonDeprecated(logOptions, &logFlags)
-
-		logFlags.VisitAll(func(f *pflag.Flag) {
-			switch f.Name {
-			case "v":
-				// "cmctl check api" already had a "v" flag that did not require any value, for
-				// backwards compatibility we allow the "v" logging flag to be set without a value
-				// and default to "2" (which will result in the same behaviour as before).
-				f.NoOptDefVal = "2"
-				cmds.PersistentFlags().AddFlag(f)
-			default:
-				cmds.PersistentFlags().AddFlag(f)
-			}
-		})
-	}
+	logf.AddFlagsNonDeprecated(logOptions, cmds.PersistentFlags())
 
 	ioStreams := genericclioptions.IOStreams{In: in, Out: out, ErrOut: err}
 	for _, registerCmd := range commands.Commands() {


### PR DESCRIPTION
Since we are releasing v2, I think it is acceptable that we make this breaking change.

**Reason for change:**
This flag default causes issues when you try to set the verbosity by specifying `-v 3` instead of `-v=3`.
`-v 3` is not correctly parsed because the `-v` flag has a default value.