### PR TITLE
Make uninstalling cert-manager SAFE: don't uninstal the CRDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.20.0
+	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b
 	golang.org/x/sync v0.6.0
 	helm.sh/helm/v3 v3.14.2
 	k8s.io/api v0.29.2
@@ -155,7 +156,6 @@ require (
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
-	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect


### PR DESCRIPTION
This PR modifies the uninstall command so it can be used to safely uninstall any cert-manager Helm chart without uninstalling the CRDs.
It does this by first updating the Helm release and adding the keep annotations to the CRDs, after which the uninstallation process continues.