### PR TITLE
Fix `cmctl renew` flags validation

### DIFF
--- a/pkg/renew/renew.go
+++ b/pkg/renew/renew.go
@@ -112,8 +112,8 @@ func (o *Options) Validate(cmd *cobra.Command, args []string) error {
 		return errors.New("cannot specify --namespace flag in conjunction with --all flag")
 	}
 
-	if !o.All && len(args) == 0 {
-		return errors.New("please supply one or more Certificate resource names or use the --all flag to renew all Certificate resources")
+	if !o.All && len(args) == 0 && len(o.LabelSelector) == 0 {
+		return errors.New("please either supply one or more Certificate resource names, label selectors, or use the --all flag to renew all Certificate resources")
 	}
 
 	return nil

--- a/pkg/renew/renew.go
+++ b/pkg/renew/renew.go
@@ -96,24 +96,26 @@ func NewCmdRenew(ctx context.Context, ioStreams genericclioptions.IOStreams) *co
 
 // Validate validates the provided options
 func (o *Options) Validate(cmd *cobra.Command, args []string) error {
-	if len(o.LabelSelector) > 0 && len(args) > 0 {
-		return errors.New("cannot specify Certificate names in conjunction with label selectors")
-	}
-
 	if len(o.LabelSelector) > 0 && o.All {
 		return errors.New("cannot specify label selectors in conjunction with --all flag")
 	}
 
-	if o.All && len(args) > 0 {
-		return errors.New("cannot specify Certificate names in conjunction with --all flag")
-	}
+	if len(args) == 0 {
+		if !o.All && len(o.LabelSelector) == 0 {
+			return errors.New("please either supply one or more Certificate resource names, label selectors, or use the --all flag to renew all Certificate resources")
+		}
+	} else {
+		if len(o.LabelSelector) > 0 {
+			return errors.New("cannot specify Certificate names in conjunction with label selectors")
+		}
 
-	if o.All && cmd.PersistentFlags().Changed("namespace") {
-		return errors.New("cannot specify --namespace flag in conjunction with --all flag")
-	}
+		if o.All {
+			return errors.New("cannot specify Certificate names in conjunction with --all flag")
+		}
 
-	if !o.All && len(args) == 0 && len(o.LabelSelector) == 0 {
-		return errors.New("please either supply one or more Certificate resource names, label selectors, or use the --all flag to renew all Certificate resources")
+		if o.AllNamespaces {
+			return errors.New("cannot specify Certificate names in conjunction with --all-namespaces flag")
+		}
 	}
 
 	return nil

--- a/pkg/renew/renew_test.go
+++ b/pkg/renew/renew_test.go
@@ -53,7 +53,6 @@ func TestValidate(t *testing.T) {
 				LabelSelector: "foo=bar",
 				All:           true,
 			},
-			args:   []string{""},
 			expErr: true,
 		},
 		"If there are all certificates selected, as well as arguments, error": {

--- a/pkg/renew/renew_test.go
+++ b/pkg/renew/renew_test.go
@@ -95,6 +95,29 @@ func TestValidate(t *testing.T) {
 			},
 			expErr: false,
 		},
+		"If --label-selector specified with --all, error": {
+			options: &Options{
+				LabelSelector: "foo=bar",
+				All:           true,
+			},
+			expErr: true,
+		},
+		"If --label-selector specified with --all-namespaces, don't error": {
+			options: &Options{
+				AllNamespaces: true,
+				LabelSelector: "foo=bar",
+			},
+			expErr: false,
+		},
+		"If --label-selector specified with --namespace, don't error": {
+			options: &Options{
+				LabelSelector: "foo=bar",
+			},
+			setStringFlags: []stringFlag{
+				{name: "namespace", value: "foo"},
+			},
+			expErr: false,
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/renew/renew_test.go
+++ b/pkg/renew/renew_test.go
@@ -41,6 +41,13 @@ func TestValidate(t *testing.T) {
 			args:   []string{"abc"},
 			expErr: true,
 		},
+		"If there are arguments, as well as --all-namespaces, error": {
+			options: &Options{
+				AllNamespaces: true,
+			},
+			args:   []string{"abc"},
+			expErr: true,
+		},
 		"If there are all certificates selected, as well as label selector, error": {
 			options: &Options{
 				LabelSelector: "foo=bar",
@@ -63,14 +70,14 @@ func TestValidate(t *testing.T) {
 			},
 			expErr: false,
 		},
-		"If --namespace and --all namespace specified, error": {
+		"If --namespace and --all specified, don't error": {
 			options: &Options{
 				All: true,
 			},
 			setStringFlags: []stringFlag{
 				{name: "namespace", value: "foo"},
 			},
-			expErr: true,
+			expErr: false,
 		},
 		"If --namespace specified without arguments, error": {
 			options: &Options{},


### PR DESCRIPTION
Hey folks 👋🏻 

While using `cmctl renew` earlier today, we noticed some bugs in the flags that caused an error when running `cmctl renew --all-namespaces -l app=my-service` as documented in the CLI help.

The error we saw:
```
please supply one or more Certificate resource names or use the --all flag to renew all Certificate resources
```

I made an attempt to fix this bug in the renew validation function, so keen to hear your thoughts on it 😄
- The first commit outlines the main change
- The second commit proposes a refactor to make the mutually exclusive options (hopefully) clearer

I've also updated the tests accordingly!

## Reasoning

Based on my understanding of the actual `Run` command, I believe these hold true:

- Mutually exclusive flags:
  - `--all` and `--label-selectors`
- If no arguments are specified:
  - We need either `--all` or `--label-selectors`
- If arguments are specified:
  - They can't be used with `--all`, or `--label-selectors`
  - You would get an `Error from server (NotFound)`: error with `--all-namespaces`, unless the first namespace that is [listed](https://github.com/cert-manager/cmctl/blob/c42c489dd0af74bb6a6568ea55e86cced39b4dc2/pkg/renew/renew.go#L154) happens to contain the certificate(s) specified in the arguments.
    - This behaviour doesn't sound ideal so I think it's more intuitive to disallow use of arguments with `--all-namespaces`; arguments should really only be used with `--namespace`.