### PR TITLE
Cleanup uninstall flags

### DIFF
--- a/pkg/install/helm/flags.go
+++ b/pkg/install/helm/flags.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// Flags that are shared between the Install and the Uninstall command
+func AddInstallUninstallFlags(f *pflag.FlagSet, timeout *time.Duration, wait *bool) {
+	f.DurationVar(timeout, "timeout", 300*time.Second, "Time to wait for any individual Kubernetes operation (like Jobs for hooks)")
+	f.MarkHidden("timeout")
+	f.BoolVar(wait, "wait", true, "If set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout")
+	f.MarkHidden("wait")
+}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -112,7 +112,7 @@ func NewCmdInstall(ctx context.Context, ioStreams genericclioptions.IOStreams) *
 
 	settings.Setup(ctx, cmd)
 
-	addInstallUninstallFlags(cmd.Flags(), &options.client.Timeout, &options.Wait)
+	helm.AddInstallUninstallFlags(cmd.Flags(), &options.client.Timeout, &options.Wait)
 
 	addInstallFlags(cmd.Flags(), options.client)
 	addValueOptionsFlags(cmd.Flags(), options.valueOpts)

--- a/pkg/install/util.go
+++ b/pkg/install/util.go
@@ -19,21 +19,12 @@ package install
 import (
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/spf13/pflag"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli/values"
 	"k8s.io/client-go/util/homedir"
 )
-
-// Flags that are shared between the Install and the Uninstall command
-func addInstallUninstallFlags(f *pflag.FlagSet, timeout *time.Duration, wait *bool) {
-	f.DurationVar(timeout, "timeout", 300*time.Second, "Time to wait for any individual Kubernetes operation (like Jobs for hooks)")
-	f.MarkHidden("timeout")
-	f.BoolVar(wait, "wait", true, "If set, will wait until all Pods, PVCs, Services, and minimum number of Pods of a Deployment, StatefulSet, or ReplicaSet are in a ready state before marking the release as successful. It will wait for as long as --timeout")
-	f.MarkHidden("wait")
-}
 
 func addInstallFlags(f *pflag.FlagSet, client *action.Install) {
 	f.StringVar(&client.ReleaseName, "release-name", "cert-manager", "Name of the helm release")
@@ -42,7 +33,7 @@ func addInstallFlags(f *pflag.FlagSet, client *action.Install) {
 	f.MarkHidden("generate-name")
 	f.StringVar(&client.NameTemplate, "name-template", "", "Specify template used to name the release")
 	f.MarkHidden("name-template")
-	f.StringVar(&client.Description, "description", "Cert-manager was installed using the cert-manager CLI", "Add a custom description")
+	f.StringVar(&client.Description, "description", "cert-manager was installed using the cert-manager CLI", "Add a custom description")
 	f.MarkHidden("description")
 }
 


### PR DESCRIPTION
Correctly share the shared install and uninstall flags & remove the `no-hooks` flag which does not have any use currently.