### PR TITLE
Fix gosec errors and enable gosec linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,6 @@
 issues:
   exclude-rules:
     - linters:
-        - gosec
         - nilnil
       text: ".*"
 linters:

--- a/internal/util/signal_test.go
+++ b/internal/util/signal_test.go
@@ -37,6 +37,7 @@ func testExitCode(
 		os.Exit(0)
 	}
 
+	// #nosec G204
 	cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
 	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
 	cmd.Stdout = os.Stdout

--- a/internal/versionchecker/test/testdata/fetch.go
+++ b/internal/versionchecker/test/testdata/fetch.go
@@ -290,7 +290,7 @@ func (inv *Inventory) write(manifestsPath string) error {
 		invBytes.WriteString("\n---\n")
 	}
 
-	if err := os.WriteFile(manifestsPath, invBytes.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(manifestsPath, invBytes.Bytes(), 0600); err != nil {
 		return fmt.Errorf("failed to write inventory file: %v", err)
 	}
 

--- a/pkg/create/certificaterequest/certificaterequest_test.go
+++ b/pkg/create/certificaterequest/certificaterequest_test.go
@@ -206,7 +206,7 @@ spec:
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := os.WriteFile("testfile.yaml", []byte(test.inputFileContent), 0644); err != nil {
+			if err := os.WriteFile("testfile.yaml", []byte(test.inputFileContent), 0600); err != nil {
 				t.Fatalf("error creating test file %#v", err)
 			}
 			defer os.Remove("testfile.yaml")

--- a/pkg/renew/renew.go
+++ b/pkg/renew/renew.go
@@ -211,8 +211,7 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 	}
 
 	for _, crt := range crts {
-		// #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
-		if err := o.renewCertificate(ctx, &crt); err != nil {
+		if err := o.renewCertificate(ctx, &crt); /* #nosec G601 -- Pointer does not outlive function scope */ err != nil {
 			return err
 		}
 	}

--- a/pkg/status/certificate/certificate.go
+++ b/pkg/status/certificate/certificate.go
@@ -308,9 +308,8 @@ func findMatchingCR(cmClient cmclient.Interface, ctx context.Context, crt *cmapi
 		nextRevision = *crt.Status.Revision + 1
 	}
 	for _, req := range reqs.Items {
-		// #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
-		if predicate.CertificateRequestRevision(nextRevision)(&req) &&
-			predicate.ResourceOwnedBy(crt)(&req) {
+		if predicate.CertificateRequestRevision(nextRevision)(&req) && /* #nosec G601 -- Pointer does not outlive function scope */
+			predicate.ResourceOwnedBy(crt)(&req) /* #nosec G601 -- Pointer does not outlive function scope */ {
 			possibleMatches = append(possibleMatches, req.DeepCopy())
 		}
 	}
@@ -337,8 +336,7 @@ func findMatchingOrder(cmClient cmclient.Interface, ctx context.Context, req *cm
 
 	possibleMatches := []*cmacme.Order{}
 	for _, order := range orders.Items {
-		// #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
-		if predicate.ResourceOwnedBy(req)(&order) {
+		if predicate.ResourceOwnedBy(req)(&order) /* #nosec G601 -- Pointer does not outlive function scope */ {
 			possibleMatches = append(possibleMatches, order.DeepCopy())
 		}
 	}
@@ -390,8 +388,7 @@ func findMatchingChallenges(cmClient cmclient.Interface, ctx context.Context, or
 
 	possibleMatches := []*cmacme.Challenge{}
 	for _, challenge := range challenges.Items {
-		// #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
-		if predicate.ResourceOwnedBy(order)(&challenge) {
+		if predicate.ResourceOwnedBy(order)(&challenge) /* #nosec G601 -- Pointer does not outlive function scope */ {
 			possibleMatches = append(possibleMatches, challenge.DeepCopy())
 		}
 	}

--- a/pkg/status/certificate/types.go
+++ b/pkg/status/certificate/types.go
@@ -345,7 +345,7 @@ func (secretStatus *SecretStatus) String() string {
 		return secretStatus.Error.Error()
 	}
 
-	secretFormat := `Secret:
+	detailsFormat := `Secret:
   Name: %s
   Issuer Country: %s
   Issuer Organisation: %s
@@ -363,7 +363,7 @@ func (secretStatus *SecretStatus) String() string {
 	if err != nil {
 		extKeyUsageString = err.Error()
 	}
-	output := fmt.Sprintf(secretFormat, secretStatus.Name, strings.Join(secretStatus.IssuerCountry, ", "),
+	output := fmt.Sprintf(detailsFormat, secretStatus.Name, strings.Join(secretStatus.IssuerCountry, ", "),
 		strings.Join(secretStatus.IssuerOrganisation, ", "),
 		secretStatus.IssuerCommonName, keyUsageToString(secretStatus.KeyUsage),
 		extKeyUsageString, secretStatus.PublicKeyAlgorithm, secretStatus.SignatureAlgorithm,


### PR DESCRIPTION
Checked all found issues and applied fixes/ #nosec statements.
Now that all issues are fixed, I removed the gosec linter from the ignored section so future issues will be detected.

NOTE FOR REVIEWER:
Use `make verify-golangci-lint` to quickly run golangci-lint.

I had to mix the comments with the code to make sure the nosec comments were picked up by gosec (see https://github.com/securego/gosec/issues/278#issuecomment-745209803).