### PR TITLE
`make verify-golangci-lint`: "find -printf" isn't working on macOS

### DIFF
--- a/make/_shared/go/01_mod.mk
+++ b/make/_shared/go/01_mod.mk
@@ -75,6 +75,7 @@ shared_generate_targets += generate-golangci-lint-config
 ## @category [shared] Generate/ Verify
 verify-golangci-lint: | $(NEEDS_GO) $(NEEDS_GOLANGCI-LINT) $(NEEDS_YQ) $(bin_dir)/scratch
 	@find . -name go.mod -not \( -path "./$(bin_dir)/*" -or -path "./make/_shared/*" \) \
+	    | xargs dirname \
 		| while read d; do \
 				target=$$(dirname $${d}); \
 				echo "Running '$(bin_dir)/tools/golangci-lint run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config)' in directory '$${target}'"; \
@@ -98,6 +99,7 @@ fix-golangci-lint: | $(NEEDS_GOLANGCI-LINT) $(NEEDS_YQ) $(NEEDS_GCI) $(bin_dir)/
 		-s "dot" .
 
 	@find . -name go.mod -not \( -path "./$(bin_dir)/*" -or -path "./make/_shared/*" \) \
+		| xargs dirname \
 		| while read d; do \
 				target=$$(dirname $${d}); \
 				echo "Running '$(bin_dir)/tools/golangci-lint run --go $(VENDORED_GO_VERSION) -c $(CURDIR)/$(golangci_lint_config) --fix' in directory '$${target}'"; \


### PR DESCRIPTION
On macOS, running:

```
make verify-golangci-lint
```

results in the following error message:

```
find: -printf: unknown primary or operator
```

As detailed in https://hackmd.io/@maelvls/bsd-vs-gnu-vs-busybox-incompat#find, `-printf` is specific to GNU find and doesn't work on macOS. It is possible to work around that by replacing `-printf` with something else.

The pattern `%h\n` means:

```
%h     Dirname; the Leading directories of the file's name
       (all but the last element).  If the file name
       contains no slashes (since it is in the current
       directory) the %h specifier expands to `.'.  For
       files which are themselves directories and contain
       a slash (including /), %h expands to the empty
       string.  See the EXAMPLES section for an example.
```

I figured that it could be replaced by `dirname`:

```console
# Old
$ gfind . -name go.mod -not \( -path "./_bin/*" -or -path "./make/_shared/*" \) -printf '%h\n'
.
./internal/versionchecker/test/testdata
```

```
# New
$ find . -name go.mod -not \( -path "./_bin/*" -or -path "./make/_shared/*" \) | xargs dirname
.
./internal/versionchecker/test/testdata
```

I hope that `%h` and `dirname` have exactly the same behavior 😅