### PR TITLE
Prepare for cert-manager v1.15.0: cleanup imports, point to local test package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.0
 require (
 	github.com/cert-manager/cert-manager v1.14.5
 	github.com/go-logr/logr v1.4.1
+	github.com/google/gofuzz v1.2.0
 	github.com/sergi/go-diff v1.3.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -83,7 +84,6 @@ require (
 	github.com/google/cel-go v0.17.8 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/pkg/inspect/secret/secret.go
+++ b/pkg/inspect/secret/secret.go
@@ -28,6 +28,8 @@ import (
 	"text/template"
 	"time"
 
+	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
 	"github.com/spf13/cobra"
@@ -211,10 +213,18 @@ func describeValidFor(cert *x509.Certificate) (string, error) {
 		URIs:           printSlice(pki.URLsToString(cert.URIs)),
 		IPAddresses:    printSlice(pki.IPAddressesToString(cert.IPAddresses)),
 		EmailAddresses: printSlice(cert.EmailAddresses),
-		KeyUsage:       printKeyUsage(pki.BuildCertManagerKeyUsages(cert.KeyUsage, cert.ExtKeyUsage)),
+		KeyUsage:       printKeyUsage(buildCertManagerKeyUsages(cert.KeyUsage, cert.ExtKeyUsage)),
 	})
 
 	return b.String(), err
+}
+
+func buildCertManagerKeyUsages(ku x509.KeyUsage, eku []x509.ExtKeyUsage) []cmapi.KeyUsage {
+	var usages []cmapi.KeyUsage
+	usages = append(usages, apiutil.KeyUsageStrings(ku)...)
+	usages = append(usages, apiutil.ExtKeyUsageStrings(eku)...)
+
+	return usages
 }
 
 func describeValidityPeriod(cert *x509.Certificate) (string, error) {

--- a/test/integration/migrate/ctl_upgrade_migrate_test.go
+++ b/test/integration/migrate/ctl_upgrade_migrate_test.go
@@ -22,9 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/install"
-	v1 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v1"
-	v2 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v2"
 	apiextinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +32,9 @@ import (
 
 	"github.com/cert-manager/cmctl/v2/pkg/upgrade/migrateapiversion"
 	"github.com/cert-manager/cmctl/v2/test/integration/framework"
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/install"
+	v1 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v1"
+	v2 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v2"
 )
 
 // Create a test resource at a given version.

--- a/test/integration/migrate/ctl_upgrade_migrate_test.go
+++ b/test/integration/migrate/ctl_upgrade_migrate_test.go
@@ -22,9 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/install"
-	v1 "github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/v1"
-	v2 "github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/v2"
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/install"
+	v1 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v1"
+	v2 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v2"
 	apiextinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/integration/testdata/apis/testgroup/fuzzer/fuzzer.go
+++ b/test/integration/testdata/apis/testgroup/fuzzer/fuzzer.go
@@ -17,7 +17,7 @@ limitations under the License.
 package fuzzer
 
 import (
-	"github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	fuzz "github.com/google/gofuzz"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/utils/ptr"

--- a/test/integration/testdata/apis/testgroup/fuzzer/fuzzer.go
+++ b/test/integration/testdata/apis/testgroup/fuzzer/fuzzer.go
@@ -17,10 +17,11 @@ limitations under the License.
 package fuzzer
 
 import (
-	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	fuzz "github.com/google/gofuzz"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/utils/ptr"
+
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 )
 
 // Funcs returns the fuzzer functions for the apps api group.

--- a/test/integration/testdata/apis/testgroup/install/install.go
+++ b/test/integration/testdata/apis/testgroup/install/install.go
@@ -19,9 +19,9 @@ limitations under the License.
 package install
 
 import (
-	"github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
-	v1 "github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/v1"
-	v2 "github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/v2"
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
+	v1 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v1"
+	v2 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )

--- a/test/integration/testdata/apis/testgroup/install/install.go
+++ b/test/integration/testdata/apis/testgroup/install/install.go
@@ -19,11 +19,12 @@ limitations under the License.
 package install
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
 	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	v1 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v1"
 	v2 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v2"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 // Install registers the API group and adds types to a scheme

--- a/test/integration/testdata/apis/testgroup/install/roundtrip_test.go
+++ b/test/integration/testdata/apis/testgroup/install/roundtrip_test.go
@@ -19,7 +19,7 @@ package install
 import (
 	"testing"
 
-	"github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/fuzzer"
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/fuzzer"
 	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
 )
 

--- a/test/integration/testdata/apis/testgroup/install/roundtrip_test.go
+++ b/test/integration/testdata/apis/testgroup/install/roundtrip_test.go
@@ -19,8 +19,9 @@ package install
 import (
 	"testing"
 
-	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/fuzzer"
 	"k8s.io/apimachinery/pkg/api/apitesting/roundtrip"
+
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/fuzzer"
 )
 
 func TestRoundTripTypes(t *testing.T) {

--- a/test/integration/testdata/apis/testgroup/v1/doc.go
+++ b/test/integration/testdata/apis/testgroup/v1/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +k8s:conversion-gen=github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup
+// +k8s:conversion-gen=github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup
 // +k8s:deepcopy-gen=package,register
 // +k8s:defaulter-gen=TypeMeta
 

--- a/test/integration/testdata/apis/testgroup/v1/register.go
+++ b/test/integration/testdata/apis/testgroup/v1/register.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 import (
-	"github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/test/integration/testdata/apis/testgroup/v1/register.go
+++ b/test/integration/testdata/apis/testgroup/v1/register.go
@@ -17,10 +17,11 @@ limitations under the License.
 package v1
 
 import (
-	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/test/integration/testdata/apis/testgroup/v1/zz_generated.conversion.go
+++ b/test/integration/testdata/apis/testgroup/v1/zz_generated.conversion.go
@@ -23,7 +23,7 @@ package v1
 import (
 	unsafe "unsafe"
 
-	testgroup "github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
+	testgroup "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/test/integration/testdata/apis/testgroup/v2/convert.go
+++ b/test/integration/testdata/apis/testgroup/v2/convert.go
@@ -19,8 +19,9 @@ package v2
 import (
 	"unsafe"
 
-	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	"k8s.io/apimachinery/pkg/conversion"
+
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 )
 
 func Convert_v2_TestType_To_testgroup_TestType(in *TestType, out *testgroup.TestType, s conversion.Scope) error {

--- a/test/integration/testdata/apis/testgroup/v2/convert.go
+++ b/test/integration/testdata/apis/testgroup/v2/convert.go
@@ -19,7 +19,7 @@ package v2
 import (
 	"unsafe"
 
-	"github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	"k8s.io/apimachinery/pkg/conversion"
 )
 

--- a/test/integration/testdata/apis/testgroup/v2/doc.go
+++ b/test/integration/testdata/apis/testgroup/v2/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +k8s:conversion-gen=github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup
+// +k8s:conversion-gen=github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup
 // +k8s:deepcopy-gen=package,register
 // +k8s:defaulter-gen=TypeMeta
 

--- a/test/integration/testdata/apis/testgroup/v2/register.go
+++ b/test/integration/testdata/apis/testgroup/v2/register.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v2
 
 import (
-	"github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/test/integration/testdata/apis/testgroup/v2/register.go
+++ b/test/integration/testdata/apis/testgroup/v2/register.go
@@ -17,10 +17,11 @@ limitations under the License.
 package v2
 
 import (
-	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 )
 
 // SchemeGroupVersion is group version used to register these objects

--- a/test/integration/testdata/apis/testgroup/v2/zz_generated.conversion.go
+++ b/test/integration/testdata/apis/testgroup/v2/zz_generated.conversion.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v2
 
 import (
-	testgroup "github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
+	testgroup "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/test/integration/testdata/apis/testgroup/validation/validation.go
+++ b/test/integration/testdata/apis/testgroup/validation/validation.go
@@ -17,11 +17,12 @@ limitations under the License.
 package validation
 
 import (
-	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
-	v1 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
+	v1 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v1"
 )
 
 func ValidateTestType(_ *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {

--- a/test/integration/testdata/apis/testgroup/validation/validation.go
+++ b/test/integration/testdata/apis/testgroup/validation/validation.go
@@ -17,8 +17,8 @@ limitations under the License.
 package validation
 
 import (
-	"github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
-	v1 "github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/v1"
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
+	v1 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v1"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/test/integration/testdata/apis/testgroup/validation/validation_test.go
+++ b/test/integration/testdata/apis/testgroup/validation/validation_test.go
@@ -20,8 +20,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
-	v1 "github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/v1"
+	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
+	v1 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 

--- a/test/integration/testdata/apis/testgroup/validation/validation_test.go
+++ b/test/integration/testdata/apis/testgroup/validation/validation_test.go
@@ -20,9 +20,10 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
 	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 	v1 "github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup/v1"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func TestValidateTestType(t *testing.T) {


### PR DESCRIPTION
In preparation for cert-manager v1.15.0, we had to fix a few issues in this repo:
- replace 	"github.com/cert-manager/cert-manager/pkg/webhook/handlers/testdata" with "github.com/cert-manager/cmctl/v2/test/integration/testdata"
- prepare for pki.BuildCertManagerKeyUsages which will be removed
- prepare for context parameter for `c.Run(..)`