### PR TITLE
testdata fetcher: add exception for the v1.15.0-beta.0 release which was abandoned

### DIFF
--- a/internal/versionchecker/test/testdata/fetch.go
+++ b/internal/versionchecker/test/testdata/fetch.go
@@ -42,6 +42,10 @@ const downloadURL = "https://github.com/cert-manager/cert-manager/releases/downl
 
 const dummyVersion = "v99.99.99"
 
+var ignoredVersions = map[string]struct{}{
+	"v1.15.0-beta.0": {}, // This beta release was abandoned when we detected a bug in the release process.
+}
+
 func main() {
 	ctx := context.Background()
 	stdOut := os.Stdout
@@ -79,6 +83,11 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(stdOut, "Error listing versions: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Remove any ignored versions
+	for version := range ignoredVersions {
+		delete(remoteVersions, version)
 	}
 
 	// List the remote versions that are not in the inventory


### PR DESCRIPTION
The testdata fetcher tries to fetch the released yaml files based on the git tags in the cert-manager repo.
For the v1.15.0-beta.0 release, there is a git tag, but no release.
That is why we add it as an exception in the fetcher now.