### PR TITLE
Add tar.gz artifacts to the GH releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,10 @@ signs:
 archives:
   - name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
     format: binary
+    
+  - id: tar-gz-archives
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
+    format: tar.gz
 
 release:
   draft: true


### PR DESCRIPTION
Fixes https://github.com/cert-manager/cmctl/issues/37

krew only supports tar.gz artifacts. This PR adds these artifacts to our goreleaser configuration.