### PR TITLE
Add v1.15.2-alpha.0 as an exception to fetch

### DIFF
--- a/internal/versionchecker/test/testdata/fetch.go
+++ b/internal/versionchecker/test/testdata/fetch.go
@@ -43,7 +43,8 @@ const downloadURL = "https://github.com/cert-manager/cert-manager/releases/downl
 const dummyVersion = "v99.99.99"
 
 var ignoredVersions = map[string]struct{}{
-	"v1.15.0-beta.0": {}, // This beta release was abandoned when we detected a bug in the release process.
+	"v1.15.0-beta.0":  {}, // This beta release was abandoned when we detected a bug in the release process.
+	"v1.15.2-alpha.0": {}, // This beta release was abandoned when we detected a bug in the release process.
 }
 
 func main() {


### PR DESCRIPTION
Since the `v1.15.2-alpha.0` version does not have release artifacts (release process was abandoned), we add it as an exception.
This will fix the following error: https://github.com/cert-manager/cmctl/actions/runs/10436636790/job/28901922299