### PR TITLE
WIP: Update goreleaser to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 # Our Makefile will automatically add additional settings
 # to this builds array (environment variables, flags, ...)
 builds:
@@ -33,11 +35,11 @@ signs:
 
 archives:
   - name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
-    format: binary
-    
+    formats: ["binary"]
+
   - id: tar-gz-archives
     name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
-    format: tar.gz
+    formats: ["tar.gz"]
 
 release:
   draft: true


### PR DESCRIPTION
Depends on https://github.com/cert-manager/makefile-modules/pull/306
 * https://github.com/cert-manager/makefile-modules/pull/306

goreleaser release notes:

* https://github.com/goreleaser/goreleaser/releases/tag/v2.11.0
* https://github.com/goreleaser/goreleaser/releases/tag/v2.0.0
* https://goreleaser.com/blog/goreleaser-v2/#upgrading