### PR TITLE
Migrate away from archived github.com/google/gofuzz

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.2
 require (
 	github.com/cert-manager/cert-manager v1.18.2
 	github.com/go-logr/logr v1.4.3
-	github.com/google/gofuzz v1.2.0
 	github.com/sergi/go-diff v1.4.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.7

--- a/test/integration/testdata/apis/testgroup/fuzzer/fuzzer.go
+++ b/test/integration/testdata/apis/testgroup/fuzzer/fuzzer.go
@@ -17,9 +17,9 @@ limitations under the License.
 package fuzzer
 
 import (
-	fuzz "github.com/google/gofuzz"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/randfill"
 
 	"github.com/cert-manager/cmctl/v2/test/integration/testdata/apis/testgroup"
 )
@@ -27,8 +27,8 @@ import (
 // Funcs returns the fuzzer functions for the apps api group.
 var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
-		func(s *testgroup.TestType, c fuzz.Continue) {
-			c.FuzzNoCustom(s) // fuzz self without calling this function again
+		func(s *testgroup.TestType, c randfill.Continue) {
+			c.FillNoCustom(s) // fuzz self without calling this function again
 
 			if s.TestFieldPtr == nil {
 				s.TestFieldPtr = ptr.To("teststr")


### PR DESCRIPTION
Was triggered by the new Renovate Dashboard: https://github.com/cert-manager/cmctl/issues/278