### PR TITLE
Ungroup cert-manager dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,4 +3,13 @@
   extends: [
     'github>cert-manager/renovate-config:default.json5',
   ],
+  packageRules: [
+    {
+      // FIXME: Ungroup cert-manager for now, since we currently depend on a pseudo-version that Renovate doesn't understand.
+      groupName: null,
+      matchPackageNames: [
+        'github.com/cert-manager/cert-manager',
+      ],
+    }
+  ],
 }


### PR DESCRIPTION
Mainly to take it out of https://github.com/cert-manager/cmctl/pull/303, to allow other upgrades to be merged.

/cc @ThatsMrTalbot 