### PR TITLE
feat: publish images on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,12 @@ jobs:
 
       - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
         with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }} 
+
+      - uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/klone.yaml
+++ b/klone.yaml
@@ -42,6 +42,16 @@ targets:
       repo_ref: main
       repo_hash: c28bd0abb20c7b89754f4e5cc44420975c6ea5f1
       repo_path: modules/klone
+    - folder_name: oci-build
+      repo_url: https://github.com/cert-manager/makefile-modules.git
+      repo_ref: main
+      repo_hash: c28bd0abb20c7b89754f4e5cc44420975c6ea5f1
+      repo_path: modules/oci-build
+    - folder_name: oci-publish
+      repo_url: https://github.com/cert-manager/makefile-modules.git
+      repo_ref: main
+      repo_hash: c28bd0abb20c7b89754f4e5cc44420975c6ea5f1
+      repo_path: modules/oci-publish
     - folder_name: repository-base
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -14,6 +14,7 @@
 
 repo_name := github.com/cert-manager/cmctl
 
+build_names := cmctl
 exe_build_names := cmctl
 gorelease_file := .goreleaser.yml
 
@@ -24,3 +25,8 @@ go_cmctl_ldflags := \
 	-X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=$(GITCOMMIT)
 
 golangci_lint_config := .golangci.yaml
+
+oci_cmctl_base_image_flavor := static
+oci_cmctl_image_name := quay.io/jetstack/cmctl
+oci_cmctl_image_tag := $(VERSION)
+oci_cmctl_image_name_development := cert-manager.local/cmctl

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -52,5 +52,6 @@ shared_generate_targets += generate-conversion
 ## @category [shared] Release
 release: | $(NEEDS_CRANE) $(bin_dir)/scratch
 	$(MAKE) exe-publish
+	$(MAKE) oci-push-cmctl
 
 	@echo "Release complete!"

--- a/make/_shared/oci-build/00_mod.mk
+++ b/make/_shared/oci-build/00_mod.mk
@@ -1,0 +1,135 @@
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use distroless as minimal base image to package the manager binary
+# To get latest SHA run "crane digest quay.io/jetstack/base-static:latest"
+base_image_static := quay.io/jetstack/base-static@sha256:1da2e7de36c9d7a1931d765e8054a3c9fe7ed5126bacf728bb7429e923386146
+
+# Use custom apko-built image as minimal base image to package the manager binary
+# To get latest SHA run "crane digest quay.io/jetstack/base-static-csi:latest"
+base_image_csi-static := quay.io/jetstack/base-static-csi@sha256:05ec9b9d5798fdd80680a54eab9eb69134d3cdaae948935bb1af07dadeb6e9be
+
+# Utility functions
+fatal_if_undefined = $(if $(findstring undefined,$(origin $1)),$(error $1 is not set))
+fatal_if_deprecated_defined = $(if $(findstring undefined,$(origin $1)),,$(error $1 is deprecated, use $2 instead))
+
+# Validate globals that are required
+$(call fatal_if_undefined,build_names)
+
+# Set default config values
+CGO_ENABLED ?= 0
+GOEXPERIMENT ?=  # empty by default
+oci_platforms ?= linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le
+
+# Default variables per build_names entry
+#
+# $1 - build_name
+define default_per_build_variables
+go_$1_cgo_enabled ?= $(CGO_ENABLED)
+go_$1_goexperiment ?= $(GOEXPERIMENT)
+go_$1_flags ?= -tags=
+oci_$1_platforms ?= $(oci_platforms)
+oci_$1_additional_layers ?= 
+oci_$1_linux_capabilities ?= 
+oci_$1_build_args ?= 
+endef
+
+$(foreach build_name,$(build_names),$(eval $(call default_per_build_variables,$(build_name))))
+
+# Validate variables per build_names entry
+#
+# $1 - build_name
+define check_per_build_variables
+# Validate deprecated variables
+$(call fatal_if_deprecated_defined,cgo_enabled_$1,go_$1_cgo_enabled)
+$(call fatal_if_deprecated_defined,goexperiment_$1,go_$1_goexperiment)
+$(call fatal_if_deprecated_defined,oci_additional_layers_$1,oci_$1_additional_layers)
+
+# Validate required config exists
+$(call fatal_if_undefined,go_$1_ldflags)
+$(call fatal_if_undefined,go_$1_main_dir)
+$(call fatal_if_undefined,go_$1_mod_dir)
+$(call fatal_if_undefined,oci_$1_base_image_flavor)
+$(call fatal_if_undefined,oci_$1_image_name_development)
+
+# Validate we have valid base image config
+ifeq ($(oci_$1_base_image_flavor),static)
+    oci_$1_base_image := $(base_image_static)
+else ifeq ($(oci_$1_base_image_flavor),csi-static)
+    oci_$1_base_image := $(base_image_csi-static)
+else ifeq ($(oci_$1_base_image_flavor),custom)
+    $$(call fatal_if_undefined,oci_$1_base_image)
+else
+    $$(error oci_$1_base_image_flavor has unknown value "$(oci_$1_base_image_flavor)")
+endif
+
+# Validate the config required to build the golang based images
+ifneq ($(go_$1_main_dir:.%=.),.)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES start with ".")
+endif
+ifeq ($(go_$1_main_dir:%/=/),/)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES NOT end with "/")
+endif
+ifeq ($(go_$1_main_dir:%.go=.go),.go)
+$$(error go_$1_main_dir "$(go_$1_main_dir)" should be a directory path that DOES NOT end with ".go")
+endif
+ifneq ($(go_$1_mod_dir:.%=.),.)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory path that DOES start with ".")
+endif
+ifeq ($(go_$1_mod_dir:%/=/),/)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory path that DOES NOT end with "/")
+endif
+ifeq ($(go_$1_mod_dir:%.go=.go),.go)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" should be a directory path that DOES NOT end with ".go")
+endif
+ifeq ($(wildcard $(go_$1_mod_dir)/go.mod),)
+$$(error go_$1_mod_dir "$(go_$1_mod_dir)" does not contain a go.mod file)
+endif
+ifeq ($(wildcard $(go_$1_mod_dir)/$(go_$1_main_dir)/main.go),)
+$$(error go_$1_main_dir "$(go_$1_mod_dir)/$(go_$1_main_dir)" does not contain a main.go file)
+endif
+
+# Validate the config required to build OCI images
+ifneq ($(words $(oci_$1_image_name_development)),1)
+$$(error oci_$1_image_name_development "$(oci_$1_image_name_development)" should be a single image name)
+endif
+
+# Validate that the build name does not end in __local
+ifeq ($(1:%__local=__local),__local)
+$$(error build_name "$1" SHOULD NOT end in __local)
+endif
+endef
+
+$(foreach build_name,$(build_names),$(eval $(call check_per_build_variables,$(build_name))))
+
+# Create variables holding targets
+#
+# We create the following targets for each $(build_names)
+# - oci-build-$(build_name) = build the oci directory (multi-arch)
+# - oci-build-$(build_name)__local = build the oci directory (local arch: linux/$(HOST_ARCH))
+# - oci-load-$(build_name) = load the image into docker using the oci_$(build_name)_image_name_development variable
+# - docker-tarball-$(build_name) = build a "docker load" compatible tarball of the image
+oci_build_targets := $(build_names:%=oci-build-%)
+oci_build_targets += $(build_names:%=oci-build-%__local)
+oci_load_targets := $(build_names:%=oci-load-%)
+docker_tarball_targets := $(build_names:%=docker-tarball-%)
+
+# Derive config based on user config
+# 
+# - oci_layout_path_$(build_name) = path that the OCI image will be saved in OCI layout directory format
+# - oci_digest_path_$(build_name) = path to the file that will contain the digests
+# - docker_tarball_path_$(build_name) = path that the docker tarball that the docker-tarball-$(build_name) will produce
+$(foreach build_name,$(build_names),$(eval oci_layout_path_$(build_name) := $(bin_dir)/scratch/image/oci-layout-$(build_name)))
+$(foreach build_name,$(build_names),$(eval oci_digest_path_$(build_name) := $(CURDIR)/$(oci_layout_path_$(build_name)).digests))
+$(foreach build_name,$(build_names),$(eval docker_tarball_path_$(build_name) := $(CURDIR)/$(oci_layout_path_$(build_name)).docker.tar))

--- a/make/_shared/oci-build/01_mod.mk
+++ b/make/_shared/oci-build/01_mod.mk
@@ -1,0 +1,83 @@
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$(bin_dir)/scratch/image:
+	@mkdir -p $@
+
+.PHONY: $(oci_build_targets)
+## Build the OCI image.
+## - oci-build-$(build_name) = build the oci directory (multi-arch)
+## - oci-build-$(build_name)__local = build the oci directory (local arch: linux/$(HOST_ARCH))
+## @category [shared] Build
+$(oci_build_targets): oci-build-%: | $(NEEDS_KO) $(NEEDS_GO) $(NEEDS_YQ) $(NEEDS_IMAGE-TOOL) $(bin_dir)/scratch/image
+	$(eval a := $(patsubst %__local,%,$*))
+	$(eval is_local := $(if $(findstring $a__local,$*),true))
+	$(eval layout_path := $(if $(is_local),$(oci_layout_path_$a).local,$(oci_layout_path_$a)))
+	$(eval digest_path := $(if $(is_local),$(oci_digest_path_$a).local,$(oci_digest_path_$a)))
+
+	rm -rf $(CURDIR)/$(layout_path)
+
+	echo '{}' | \
+		$(YQ) '.defaultBaseImage = "$(oci_$a_base_image)"' | \
+		$(YQ) '.builds[0].id = "$a"' | \
+		$(YQ) '.builds[0].dir = "$(go_$a_mod_dir)"' | \
+		$(YQ) '.builds[0].main = "$(go_$a_main_dir)"' | \
+		$(YQ) '.builds[0].env[0] = "CGO_ENABLED=$(go_$a_cgo_enabled)"' | \
+		$(YQ) '.builds[0].env[1] = "GOEXPERIMENT=$(go_$a_goexperiment)"' | \
+		$(YQ) '.builds[0].ldflags[0] = "-s"' | \
+		$(YQ) '.builds[0].ldflags[1] = "-w"' | \
+		$(YQ) '.builds[0].ldflags[2] = "{{.Env.LDFLAGS}}"' | \
+		$(YQ) '.builds[0].flags[0] = "$(go_$a_flags)"' | \
+		$(YQ) '.builds[0].linux_capabilities = "$(oci_$a_linux_capabilities)"' \
+		> $(CURDIR)/$(layout_path).ko_config.yaml
+
+	GOWORK=off \
+	KO_DOCKER_REPO=$(oci_$a_image_name_development) \
+	KOCACHE=$(CURDIR)/$(bin_dir)/scratch/image/ko_cache \
+	KO_CONFIG_PATH=$(CURDIR)/$(layout_path).ko_config.yaml \
+	SOURCE_DATE_EPOCH=$(GITEPOCH) \
+	KO_GO_PATH=$(GO) \
+	LDFLAGS="$(go_$a_ldflags)" \
+	$(KO) build $(go_$a_mod_dir)/$(go_$a_main_dir) \
+		--platform=$(if $(is_local),linux/$(HOST_ARCH),$(oci_$a_platforms)) \
+		$(oci_$a_build_args) \
+		--oci-layout-path=$(layout_path) \
+		--sbom-dir=$(CURDIR)/$(layout_path).sbom \
+		--sbom=spdx \
+		--push=false \
+		--bare
+
+	$(IMAGE-TOOL) append-layers \
+		$(CURDIR)/$(layout_path) \
+		$(oci_$a_additional_layers)
+
+	$(IMAGE-TOOL) list-digests \
+		$(CURDIR)/$(layout_path) \
+		> $(digest_path)
+
+# Only include the oci-load target if kind is provided by the kind makefile-module
+ifdef kind_cluster_name
+.PHONY: $(oci_load_targets)
+## Build OCI image for the local architecture and load
+## it into the $(kind_cluster_name) kind cluster.
+## @category [shared] Build
+$(oci_load_targets): oci-load-%: docker-tarball-% | kind-cluster $(NEEDS_KIND)
+	$(KIND) load image-archive --name $(kind_cluster_name) $(docker_tarball_path_$*)
+endif
+
+## Build Docker tarball image for the local architecture
+## @category [shared] Build
+.PHONY: $(docker_tarball_targets)
+$(docker_tarball_targets): docker-tarball-%: oci-build-%__local | $(NEEDS_GO) $(NEEDS_IMAGE-TOOL)
+	$(IMAGE-TOOL) convert-to-docker-tar $(CURDIR)/$(oci_layout_path_$*).local $(docker_tarball_path_$*) $(oci_$*_image_name_development):$(oci_$*_image_tag)

--- a/make/_shared/oci-publish/00_mod.mk
+++ b/make/_shared/oci-publish/00_mod.mk
@@ -1,0 +1,58 @@
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Push names is equivalent to build_names, additional names can be added for 
+# pushing images that are not build with the oci-build module
+push_names ?=
+push_names += $(build_names)
+
+# Sometimes we need to push to one registry, but pull from another. This allows
+# that.
+#
+# The lines should be in the format a=b
+#
+# The value on the left is the domain you include in your oci_<name>_image_name
+# variable, the one on the right is the domain that is actually pushed to.
+#
+# For example, if we set up a vanity domain for the current quay:
+# 
+#   oci_controller_image_name = registry.cert-manager.io/cert-manager-controller` 
+#   image_registry_rewrite += registry.cert-manager.io=quay.io/jetstack
+#
+# This would push to quay.io/jetstack/cert-manager-controller.
+#
+# The general idea is oci_<name>_image_name contains the final image name, after replication, after vanity domains etc.
+
+image_registry_rewrite ?= 
+
+# Utilities for extracting the key and value from a foo=bar style line
+kv_key = $(word 1,$(subst =, ,$1))
+kv_value = $(word 2,$(subst =, ,$1))
+
+# Apply the image_registry_rewrite rules, if no rules match an image then the 
+# image name is not changed. Any rules that match will be applied.
+#
+# For example, if there was a rule vanity-domain.com=real-registry.com/foo
+# then any references to vanity-domain.com/image would be rewritten to 
+# real-registry.com/foo/image
+image_registry_rewrite_rules_for_image = $(strip $(sort $(foreach rule,$(image_registry_rewrite),$(if $(findstring $(call kv_key,$(rule)),$1),$(rule)))))
+apply_image_registry_rewrite_rules_to_image = $(if $(call image_registry_rewrite_rules_for_image,$1),\
+	$(foreach rule,$(call image_registry_rewrite_rules_for_image,$1),$(subst $(call kv_key,$(rule)),$(call kv_value,$(rule)),$1)),\
+	$1)
+apply_image_registry_rewrite_rules = $(foreach image_name,$1,$(call apply_image_registry_rewrite_rules_to_image,$(image_name)))
+
+# This is a helper function to return the image names for a given build_name.
+# It will apply all rewrite rules to the image names
+oci_image_names_for = $(call apply_image_registry_rewrite_rules,$(oci_$1_image_name))
+oci_image_tag_for = $(oci_$1_image_tag)

--- a/make/_shared/oci-publish/01_mod.mk
+++ b/make/_shared/oci-publish/01_mod.mk
@@ -1,0 +1,127 @@
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Utility functions
+fatal_if_undefined = $(if $(findstring undefined,$(origin $1)),$(error $1 is not set))
+oci_digest = $(shell head -1 $(oci_digest_path_$1) 2> /dev/null)
+sanitize_target = $(subst :,-,$1)
+registry_for = $(firstword $(subst /, ,$1))
+
+# Utility variables
+current_makefile_directory := $(dir $(lastword $(MAKEFILE_LIST)))
+image_exists_script := $(current_makefile_directory)/image-exists.sh
+
+# Validate globals that are required
+$(call fatal_if_undefined,bin_dir)
+$(call fatal_if_undefined,push_names)
+
+# Set default config values
+RELEASE_DRYRUN ?= false
+CRANE_FLAGS ?= # empty by default
+COSIGN_FLAGS ?= # empty by default
+OCI_SIGN_ON_PUSH ?= true
+
+# Default variables per push_names entry
+#
+# $1 - build_name
+define default_per_build_variables
+release_dryrun_$1 ?= $(RELEASE_DRYRUN)
+crane_flags_$1 ?= $(CRANE_FLAGS)
+cosign_flags_$1 ?= $(COSIGN_FLAGS)
+oci_sign_on_push_$1 ?= $(OCI_SIGN_ON_PUSH)
+endef
+
+$(foreach build_name,$(push_names),$(eval $(call default_per_build_variables,$(build_name))))
+
+# Validate variables per push_names entry
+#
+# $1 - build_name
+define check_per_build_variables
+$(call fatal_if_undefined,oci_digest_path_$1)
+$(call fatal_if_undefined,oci_layout_path_$1)
+$(call fatal_if_undefined,oci_$1_image_name)
+$(call fatal_if_undefined,oci_$1_image_tag)
+endef
+
+$(foreach build_name,$(push_names),$(eval $(call check_per_build_variables,$(build_name))))
+
+# Create variables holding targets
+#
+# We create the following targets for each $(push_names)
+# - oci-build-$(build_name) = build the oci directory
+# - oci-load-$(build_name) = load the image into docker using the oci_$(build_name)_image_name_development variable
+# - docker-tarball-$(build_name) = build a "docker load" compatible tarball of the image
+# - ko-config-$(build_name) = generate "ko" config for a given build
+oci_push_targets := $(push_names:%=oci-push-%)
+oci_sign_targets := $(push_names:%=oci-sign-%)
+oci_maybe_push_targets := $(push_names:%=oci-maybe-push-%)
+
+# Define push target 
+# $1 - build_name
+# $2 - image_name
+define oci_push_target
+.PHONY: $(call sanitize_target,oci-push-$2)
+$(call sanitize_target,oci-push-$2): oci-build-$1 | $(NEEDS_CRANE)
+	$$(CRANE) $(crane_flags_$1) push "$(oci_layout_path_$1)" "$2:$(call oci_image_tag_for,$1)"
+	$(if $(filter true,$(oci_sign_on_push_$1)),$(MAKE) $(call sanitize_target,oci-sign-$2))
+
+.PHONY: $(call sanitize_target,oci-maybe-push-$2)
+$(call sanitize_target,oci-maybe-push-$2): oci-build-$1 | $(NEEDS_CRANE)
+	CRANE="$$(CRANE) $(crane_flags_$1)" \
+	source $(image_exists_script) $2:$(call oci_image_tag_for,$1); \
+		$$(CRANE) $(crane_flags_$1) push "$(oci_layout_path_$1)" "$2:$(call oci_image_tag_for,$1)"; \
+		$(if $(filter true,$(oci_sign_on_push_$1)),$(MAKE) $(call sanitize_target,oci-sign-$2))
+
+oci-push-$1: $(call sanitize_target,oci-push-$2)
+oci-maybe-push-$1: $(call sanitize_target,oci-maybe-push-$2)
+endef
+
+oci_push_target_per_image = $(foreach image_name,$2,$(eval $(call oci_push_target,$1,$(image_name))))
+$(foreach build_name,$(push_names),$(eval $(call oci_push_target_per_image,$(build_name),$(call oci_image_names_for,$(build_name)))))
+
+.PHONY: $(oci_push_targets)
+## Build and push OCI image.
+## If the tag already exists, this target will overwrite it.
+## If an identical image was already built before, we will add a new tag to it, but we will not sign it again.
+## Expected pushed images:
+## - :v1.2.3, @sha256:0000001
+## - :v1.2.3.sig, :sha256-0000001.sig
+## @category [shared] Publish
+$(oci_push_targets):
+
+.PHONY: $(oci_maybe_push_targets)
+## Push image if tag does not already exist in registry.
+## @category [shared] Publish
+$(oci_maybe_push_targets):
+
+# Define sign target 
+# $1 - build_name
+# $2 - image_name
+define oci_sign_target
+.PHONY: $(call sanitize_target,oci-sign-$2)
+$(call sanitize_target,oci-sign-$2): $(oci_digest_path_$1) | $(NEEDS_CRANE) $(NEEDS_COSIGN)
+	$$(CRANE) $(crane_flags_$1) manifest $2:$$(subst :,-,$$(call oci_digest,$1)).sig > /dev/null 2>&1 || \
+		$$(COSIGN) sign --yes=true $(cosign_flags_$1) "$2@$$(call oci_digest,$1)"
+
+oci-sign-$1: $(call sanitize_target,oci-sign-$2)
+endef
+
+oci_sign_target_per_image = $(foreach image_name,$2,$(eval $(call oci_sign_target,$1,$(image_name))))
+$(foreach build_name,$(push_names),$(eval $(call oci_sign_target_per_image,$(build_name),$(call oci_image_names_for,$(build_name)))))
+
+.PHONY: $(oci_sign_targets)
+## Sign an OCI image.
+## If a signature already exists, this will not overwrite it.
+## @category [shared] Publish
+$(oci_sign_targets):

--- a/make/_shared/oci-publish/image-exists.sh
+++ b/make/_shared/oci-publish/image-exists.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script checks if a given image exists in the upstream registry, and if it
+# does, whether it contains all the expected architectures.
+
+crane=${CRANE:-}
+
+FULL_IMAGE=${1:-}
+
+function print_usage() {
+	echo "usage: $0 <full-image> [commands...]"
+}
+
+if [[ -z $FULL_IMAGE ]]; then
+	print_usage
+	echo "Missing full-image"
+	exit 1
+fi
+
+if [[ -z $crane ]]; then
+    echo "CRANE environment variable must be set to the path of the crane binary"
+    exit 1
+fi
+
+shift 1
+
+manifest=$(mktemp)
+trap 'rm -f "$manifest"' EXIT SIGINT
+
+manifest_error=$(mktemp)
+trap 'rm -f "$manifest_error"' EXIT SIGINT
+
+echo "+++ searching for $FULL_IMAGE in upstream registry"
+
+set +o errexit
+$crane manifest "$FULL_IMAGE" > "$manifest" 2> "$manifest_error"
+exit_code=$?
+set -o errexit
+
+manifest_error_data=$(cat "$manifest_error")
+if [[ $exit_code -eq 0 ]]; then
+    echo "+++ upstream registry appears to contain $FULL_IMAGE, exiting"
+	exit 0
+
+elif [[ "$manifest_error_data" == *"MANIFEST_UNKNOWN"* ]]; then
+    echo "+++ upstream registry does not contain $FULL_IMAGE, will build and push"
+    # fall through to run the commands passed to this script
+
+else
+	echo "FATAL: upstream registry returned an unexpected error: $manifest_error_data, exiting"
+	exit 1
+fi


### PR DESCRIPTION
### Pull Request Motivation

This pull request adds reusable Makefile modules for OCI image build and publish workflows, updates the build configuration to use these modules.

It also updates the release Github action to publish the image using the makefile modules.

Before this can be merged quay secrets need adding
/hold

resolves #351 

### Kind

/kind feature

### Release Note

```release-note
Publish container image for cmctl
```
