### PR TITLE
inspect secret: close response body on error path in CRL check

### DIFF
--- a/pkg/inspect/secret/util.go
+++ b/pkg/inspect/secret/util.go
@@ -106,12 +106,12 @@ func checkCRLValidCert(ctx context.Context, cert *x509.Certificate, url string) 
 	if err != nil {
 		return false, fmt.Errorf("error getting HTTP response: %w", err)
 	}
+	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, fmt.Errorf("error reading HTTP body: %w", err)
 	}
-	resp.Body.Close()
 
 	crl, err := x509.ParseRevocationList(body)
 	if err != nil {


### PR DESCRIPTION
Fixes #442

Added defer resp.Body.Close() immediately after http.Do() to ensure the response body is closed on all exit paths, not just the success path. This prevents TCP connection leaks when io.ReadAll fails.