### PR TITLE
fix(inspect): close CRL response body on io.ReadAll error path

### DIFF
--- a/pkg/inspect/secret/util.go
+++ b/pkg/inspect/secret/util.go
@@ -106,12 +106,12 @@ func checkCRLValidCert(ctx context.Context, cert *x509.Certificate, url string) 
 	if err != nil {
 		return false, fmt.Errorf("error getting HTTP response: %w", err)
 	}
+	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, fmt.Errorf("error reading HTTP body: %w", err)
 	}
-	resp.Body.Close()
 
 	crl, err := x509.ParseRevocationList(body)
 	if err != nil {


### PR DESCRIPTION
Closes #442.

## Bug

\`checkCRLValidCert\` in \`pkg/inspect/secret/util.go\` closed \`resp.Body\` only on the success path:

\`\`\`go
resp, err := http.DefaultClient.Do(req)
if err != nil {
    return false, fmt.Errorf(\"error getting HTTP response: %w\", err)
}

body, err := io.ReadAll(resp.Body)
if err != nil {
    return false, fmt.Errorf(\"error reading HTTP body: %w\", err)  // ← body leaked
}
resp.Body.Close()
\`\`\`

Any time \`io.ReadAll\` returned a non-nil error (truncated response, transport reset, peer TLS close, etc.) the function returned early and the underlying TCP connection was leaked. \`bodyclose\` doesn't catch this class of bug because the analyzer treats the body as handled as long as \`Close\` appears anywhere in the function, without verifying reachability from every error-return — same gap as the upstream \`httpresponse\` analyzer ([golang/go#75902](https://github.com/golang/go/issues/75902)).

## Fix

One-line edit: add \`defer resp.Body.Close()\` immediately after the successful \`http.Do()\` and drop the explicit post-read call. The body is now closed from every return site.

## Testing

- \`go build ./...\` — clean.
- \`go vet ./...\` — clean.
- \`go test ./pkg/inspect/secret/...\` — one unrelated pre-existing failure in \`Test_describeTrusted\` (a macOS/Go cert-string drift: \`certificate is not trusted\` vs \`signed by unknown authority\`) which is not touched by this PR and reproduces on \`main\` before the change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>