### PR TITLE
fix(inspect): always close CRL response body in checkCRLValidCert

### DIFF
--- a/pkg/inspect/secret/util.go
+++ b/pkg/inspect/secret/util.go
@@ -106,12 +106,12 @@ func checkCRLValidCert(ctx context.Context, cert *x509.Certificate, url string) 
 	if err != nil {
 		return false, fmt.Errorf("error getting HTTP response: %w", err)
 	}
+	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, fmt.Errorf("error reading HTTP body: %w", err)
 	}
-	resp.Body.Close()
 
 	crl, err := x509.ParseRevocationList(body)
 	if err != nil {


### PR DESCRIPTION
## Summary

`checkCRLValidCert` in `pkg/inspect/secret/util.go` calls `http.DefaultClient.Do` and then reads the body with `io.ReadAll`. The explicit `resp.Body.Close()` only runs after the `ReadAll` succeeds; if `io.ReadAll` returns an error the function returns early and the body is never closed, leaking the underlying TCP connection.

This PR replaces the explicit close with a `defer resp.Body.Close()` immediately after the successful `Do()` call, so both the success and the read-error path close the body. Behaviour on the happy path is unchanged.

Fixes #442