### PR TITLE
fix: harden OCSP/CRL revocation checks against SSRF and DoS

### DIFF
--- a/pkg/inspect/secret/util.go
+++ b/pkg/inspect/secret/util.go
@@ -29,10 +29,28 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"golang.org/x/crypto/ocsp"
 )
+
+const (
+	// revocationRequestTimeout bounds the total time spent contacting a single
+	// revocation endpoint (an OCSP responder or CRL distribution point)
+	revocationRequestTimeout = 10 * time.Second
+
+	// maxRevocationResponseSize caps how many bytes we read from a revocation endpoint.
+	maxRevocationResponseSize = 1 << 20 // 1 MiB
+)
+
+// revocationHTTPClient is used for all outbound OCSP and CRL requests.
+var revocationHTTPClient = &http.Client{
+	Timeout: revocationRequestTimeout,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	},
+}
 
 func fingerprintCert(cert *x509.Certificate) string {
 	if cert == nil {
@@ -61,24 +79,29 @@ func checkOCSPValidCert(ctx context.Context, leafCert, issuerCert *x509.Certific
 	}
 
 	for _, ocspServer := range leafCert.OCSPServer {
-		httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, ocspServer, bytes.NewBuffer(buffer))
-		if err != nil {
-			return false, fmt.Errorf("error creating HTTP request: %w", err)
-		}
 		ocspUrl, err := url.Parse(ocspServer)
 		if err != nil {
 			return false, fmt.Errorf("error parsing OCSP URL: %w", err)
 		}
+		// The OCSP URL comes from the untrusted certificate under inspection, so
+		// restrict it to HTTP(S) rather than dereferencing arbitrary schemes.
+		if ocspUrl.Scheme != "http" && ocspUrl.Scheme != "https" {
+			return false, fmt.Errorf("unsupported OCSP URL scheme %q, only http and https are supported", ocspUrl.Scheme)
+		}
+
+		httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, ocspServer, bytes.NewBuffer(buffer))
+		if err != nil {
+			return false, fmt.Errorf("error creating HTTP request: %w", err)
+		}
 		httpRequest.Header.Add("Content-Type", "application/ocsp-request")
 		httpRequest.Header.Add("Accept", "application/ocsp-response")
 		httpRequest.Header.Add("Host", ocspUrl.Host)
-		httpClient := &http.Client{}
-		httpResponse, err := httpClient.Do(httpRequest) // #nosec G704 -- internal request, safe SSRF
+		httpResponse, err := revocationHTTPClient.Do(httpRequest) // #nosec G704 -- URL scheme restricted to http(s), redirects disabled, response size and timeout bounded
 		if err != nil {
 			return false, fmt.Errorf("error making HTTP request: %w", err)
 		}
 		defer httpResponse.Body.Close()
-		output, err := io.ReadAll(httpResponse.Body)
+		output, err := io.ReadAll(io.LimitReader(httpResponse.Body, maxRevocationResponseSize))
 		if err != nil {
 			return false, fmt.Errorf("error reading HTTP body: %w", err)
 		}
@@ -102,13 +125,13 @@ func checkCRLValidCert(ctx context.Context, cert *x509.Certificate, url string) 
 		return false, fmt.Errorf("error creating HTTP request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req) // #nosec G704 -- CRL URL scheme validated by caller (ldap/https only)
+	resp, err := revocationHTTPClient.Do(req) // #nosec G704 -- CRL URL scheme validated by caller (ldap/https only), redirects disabled, response size and timeout bounded
 	if err != nil {
 		return false, fmt.Errorf("error getting HTTP response: %w", err)
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRevocationResponseSize))
 	if err != nil {
 		return false, fmt.Errorf("error reading HTTP body: %w", err)
 	}

--- a/pkg/inspect/secret/util.go
+++ b/pkg/inspect/secret/util.go
@@ -125,7 +125,7 @@ func checkCRLValidCert(ctx context.Context, cert *x509.Certificate, url string) 
 		return false, fmt.Errorf("error creating HTTP request: %w", err)
 	}
 
-	resp, err := revocationHTTPClient.Do(req) // #nosec G704 -- CRL URL scheme validated by caller (ldap/https only), redirects disabled, response size and timeout bounded
+	resp, err := revocationHTTPClient.Do(req) // #nosec G704 -- CRL URL scheme validated by caller, redirects disabled, response size and timeout bounded
 	if err != nil {
 		return false, fmt.Errorf("error getting HTTP response: %w", err)
 	}

--- a/pkg/inspect/secret/util_test.go
+++ b/pkg/inspect/secret/util_test.go
@@ -18,7 +18,11 @@ package secret
 
 import (
 	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -70,6 +74,45 @@ func Test_fingerprintCert(t *testing.T) {
 				t.Errorf("fingerprintCert() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// Test_checkCRLValidCert_doesNotFollowRedirects ensures that a CRL distribution
+// point cannot redirect the request to a different (e.g. internal) endpoint.
+func Test_checkCRLValidCert_doesNotFollowRedirects(t *testing.T) {
+	var internalHit atomic.Bool
+	internal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		internalHit.Store(true)
+	}))
+	defer internal.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, internal.URL, http.StatusTemporaryRedirect)
+	}))
+	defer redirector.Close()
+
+	cert := MustParseCertificate(t, testCert)
+	// The redirect response is not a valid CRL, so an error is expected
+	if _, err := checkCRLValidCert(t.Context(), cert, redirector.URL); err == nil {
+		t.Fatal("expected an error parsing the redirect response as a CRL, got nil")
+	}
+	if internalHit.Load() {
+		t.Error("checkCRLValidCert followed a redirect to another endpoint; redirects must not be followed")
+	}
+}
+
+// Test_checkOCSPValidCert_rejectsNonHTTPScheme ensures the OCSP server URL
+// is restricted to HTTP(S) rather than being dereferenced with an arbitrary scheme.
+func Test_checkOCSPValidCert_rejectsNonHTTPScheme(t *testing.T) {
+	cert := MustParseCertificate(t, testCert)
+	cert.OCSPServer = []string{"ftp://attacker.example/ocsp"}
+
+	_, err := checkOCSPValidCert(t.Context(), cert, cert)
+	if err == nil {
+		t.Fatal("expected checkOCSPValidCert to reject a non-http(s) OCSP URL, got nil error")
+	}
+	if !strings.Contains(err.Error(), "unsupported OCSP URL scheme") {
+		t.Errorf("expected an unsupported-scheme error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
# Description

## Problem
The inspect secret command reads a kubernetes.io/tls Secret and, to report revocation status, makes network requests to the OCSP and CRL URLs listed inside the certificate. Those URLs are taken at face value — and a certificate can come from an untrusted source (e.g. a Secret created by a low-privilege tenant), so the URLs should be treated as potentially attacker-influenced. The current code contacts them with no safeguards:

  - DoS: both sinks used Timeout 0 - Meaning a tarpitting or infinite-streaming endpoint hangs or OOM-kills the process.
  - CRL allow-list bypass: the ldap/https gate is only checked on the first hop, but http.DefaultClient follows redirects without re-checking scheme (https:// → http://<internal>/).
  - OCSP SSRF: no scheme check at all.

## Solution
Route all OCSP/CRL requests through a shared client with a 10s timeout and redirects disabled, cap responds with io.LimitReader (1 MiB), and restricts OCSP URLs to http(s). The misleading #nosec rationales are corrected. Legitimate certs behave unchanged.

## Test plan
- [ ] Test_checkCRLValidCert_doesNotFollowRedirects — a CRL endpoint that 307-redirects to a second server errors out, and the redirect target is never contacted.
- [ ] Test_checkOCSPValidCert_rejectsNonHTTPScheme — an ftp:// OCSP URL is rejected before any network call.
- [ ] Both new tests pass under -race.
- [ ] Existing pkg/inspect/secret tests pass unchanged
- [ ] go build ./..., go vet ./..., and gofmt clean.